### PR TITLE
Force installation of amps

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -26,9 +26,9 @@ cp -v /vagrant/license/* tomcat/shared/classes/alfresco/extension/license/
 
 # Install amp modules into alfresco.war and share.war
 mmt="/opt/alfresco/java/bin/java -jar /opt/alfresco/bin/alfresco-mmt.jar"
-$mmt install amps tomcat/webapps/alfresco.war -directory $*
+$mmt install -force amps tomcat/webapps/alfresco.war -directory $*
 $mmt list tomcat/webapps/alfresco.war
-$mmt install amps_share tomcat/webapps/share.war -directory $*
+$mmt install -force amps_share tomcat/webapps/share.war -directory $*
 $mmt list tomcat/webapps/share.war
 
 # Start Alfresco after installation


### PR DESCRIPTION
Some extensions cannot be installed by using mmt install because it would overwrite libraries of the original war file. In this case the mmt install command does not install the module, so we have to enforce it by using -force...
